### PR TITLE
Correctly setting include path for TCL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,5 +148,6 @@ if (TCL_FOUND)
             src/Configuration_tcl_wrap.cxx
             )
     set(LIBRARY_NAME tclConfiguration)
+    set(BUCKET_NAME tclConfiguration_bucket)
     O2_GENERATE_LIBRARY()
 endif ()

--- a/cmake/CommonDependencies.cmake
+++ b/cmake/CommonDependencies.cmake
@@ -24,3 +24,12 @@ o2_define_bucket(
         SYSTEMINCLUDE_DIRECTORIES
         ${Boost_INCLUDE_DIRS}
 )
+
+o2_define_bucket(
+        NAME
+        tclConfiguration_bucket
+
+        SYSTEMINCLUDE_DIRECTORIES
+        ${Boost_INCLUDE_DIRS}
+        ${TCL_INCLUDE_PATH}
+)


### PR DESCRIPTION
This cures a compilation problem, tclConfiguration library could not
be built because tcl.h is not correctly found