### PR TITLE
Force building share libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5.2 FATAL_ERROR)
+set(BUILD_SHARED_LIBS ON)
 
 # Set cmake policy by version: https://cmake.org/cmake/help/latest/manual/cmake-policies.7.html
 if(${CMAKE_VERSION} VERSION_LESS 3.12)


### PR DESCRIPTION
This is needed due to the fact Boost 1.70.0 unit_test_framework
target is otherwise selecting the static variant which conflicts
with the hardcoded BOOST_TEST_DYN_LINK.