### PR TITLE
Fix Timer's documentation about return values

### DIFF
--- a/include/Common/Timer.h
+++ b/include/Common/Timer.h
@@ -39,9 +39,9 @@ class Timer {
     /// Check if time elapsed since timer reset (or last increment set) is bigger than timeout value set.
     /// \return Returns 1 if timeout, 0 otherwise.
     int isTimeout();
-    
+
     /// \return Returns time elapsed since reset, in seconds.
-    double getTime();    
+    double getTime();
 
     /// \return Returns the time until next timeout, in seconds. This may be a negative value if timeout occured already.
     double getRemainingTime();

--- a/include/Common/Timer.h
+++ b/include/Common/Timer.h
@@ -40,10 +40,10 @@ class Timer {
     /// \return Returns 1 if timeout, 0 otherwise.
     int isTimeout();
     
-    /// \return Returns time elapsed since reset, in microseconds.
+    /// \return Returns time elapsed since reset, in seconds.
     double getTime();    
 
-    /// \return Returns the time until next timeout, in microseconds. This may be a negative value if timeout occured already.
+    /// \return Returns the time until next timeout, in seconds. This may be a negative value if timeout occured already.
     double getRemainingTime();
     
   private:


### PR DESCRIPTION
`getTime()` and `getRemainingtime()` return values in seconds, not microseconds.