### PR TITLE
Fix warning

### DIFF
--- a/src/Configuration.cxx
+++ b/src/Configuration.cxx
@@ -74,7 +74,7 @@ void ConfigFile::load(const std::string path)
       if (boost::algorithm::ends_with(filename, suffix)) {
         try {
           boost::property_tree::ini_parser::read_ini(filename, dPtr->pt);
-        } catch (boost::property_tree::ini_parser::ini_parser_error const &perr) {
+        } catch (boost::property_tree::ini_parser::ini_parser_error const& perr) {
           std::stringstream ss;
           if (perr.line()) {
             ss << perr.message() << " in " << perr.filename() << " line " << perr.line();

--- a/src/Configuration.cxx
+++ b/src/Configuration.cxx
@@ -74,7 +74,7 @@ void ConfigFile::load(const std::string path)
       if (boost::algorithm::ends_with(filename, suffix)) {
         try {
           boost::property_tree::ini_parser::read_ini(filename, dPtr->pt);
-        } catch (boost::property_tree::ini_parser::ini_parser_error perr) {
+        } catch (boost::property_tree::ini_parser::ini_parser_error const &perr) {
           std::stringstream ss;
           if (perr.line()) {
             ss << perr.message() << " in " << perr.filename() << " line " << perr.line();


### PR DESCRIPTION
`boost::property_tree::ini_parser::ini_parser_error` is polymorphic, so the compiler complains (with `-Wcatch-value`, which is enabled by default on some platforms / newer compilers), because you are basically restricting yourself to the base class.